### PR TITLE
Add dual SimHID G1000 support for dedicated PFD+MFD displays

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,11 @@
 local config = {
     simhid_g1000_identifier = {path = "COM3"},
     simhid_g1000_display = 2,
+    -- Optional: second SimHID G1000 for dual-panel mode (PFD + MFD on separate displays).
+    -- Set simhid_g1000_2_identifier to enable; simhid_g1000_2_display defaults to
+    -- simhid_g1000_display when nil.
+    simhid_g1000_2_identifier = nil,    -- e.g. {path = "COM4"}
+    simhid_g1000_2_display = nil,       -- e.g. 3
     x56_stick_identifier = {name = "Saitek Pro Flight X-56 Rhino Stick"},
     x56_throttle_identifier = {name = "Saitek Pro Flight X-56 Rhino Throttle"},
 }

--- a/simhid_g1000/msfs/g1000.lua
+++ b/simhid_g1000/msfs/g1000.lua
@@ -1,23 +1,19 @@
-local g1000_context ={}
+local g1000_context = {}
 
 local common = require('lib/common')
 
-local function start(config)
-    g1000_context.device = common.open_simhid_g1000{
-        config = config,
-        modifiers = {
-            {class = "binary", modtype = "button"},
-            {name = "SW26", modtype = "button", modparam={longpress = 2000}},
-            {name = "SW31", modtype = "button", modparam={longpress = 2000}},
-            {name = "EC8U", modtype = "button", modparam={repeat_interval = 80}},
-            {name = "EC8D", modtype = "button", modparam={repeat_interval = 80}},
-            {name = "EC8R", modtype = "button", modparam={repeat_interval = 80}},
-            {name = "EC8L", modtype = "button", modparam={repeat_interval = 80}},
-        },
-    }
-    local g1000 = g1000_context.device.events
+local modifiers = {
+    {class = "binary", modtype = "button"},
+    {name = "SW26", modtype = "button", modparam={longpress = 2000}},
+    {name = "SW31", modtype = "button", modparam={longpress = 2000}},
+    {name = "EC8U", modtype = "button", modparam={repeat_interval = 80}},
+    {name = "EC8D", modtype = "button", modparam={repeat_interval = 80}},
+    {name = "EC8R", modtype = "button", modparam={repeat_interval = 80}},
+    {name = "EC8L", modtype = "button", modparam={repeat_interval = 80}},
+}
 
-    local pfd_maps = {
+local function make_pfd_maps(g1000)
+    return {
         {event=g1000.EC1.change, action=msfs.input_event_executer("AS1000_PFD_1_NAV_Volume")},
         {event=g1000.EC2X.change, action=msfs.input_event_executer("AS1000_PFD_1_NAV_Khz")},
         {event=g1000.EC2Y.change, action=msfs.input_event_executer("AS1000_PFD_1_NAV_Mhz")},
@@ -39,7 +35,6 @@ local function start(config)
         {event=g1000.SW11.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_INC) (>H:AP_DN) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_DEC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_UP) }")},
         {event=g1000.SW12.down, action=msfs.mfwasm.rpn_executer("(>K:FLIGHT_LEVEL_CHANGE) (A:AIRSPEED INDICATED, knots) (>K:AP_SPD_VAR_SET)")},
         {event=g1000.SW13.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_DEC) (>H:AP_UP) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_INC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_DN) }")},
-
         {event=g1000.SW14.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_1)")},
         {event=g1000.SW15.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_2)")},
         {event=g1000.SW16.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_3)")},
@@ -52,7 +47,6 @@ local function start(config)
         {event=g1000.SW23.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_10)")},
         {event=g1000.SW24.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_11)")},
         {event=g1000.SW25.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_12)")},
-
         {event=g1000.EC5.change, action=msfs.input_event_executer("AS1000_PFD_1_COM_Volume")},
         {event=g1000.EC6X.change, action=msfs.input_event_executer("AS1000_PFD_1_COM_Khz")},
         {event=g1000.EC6Y.change, action=msfs.input_event_executer("AS1000_PFD_1_COM_Mhz")},
@@ -69,7 +63,6 @@ local function start(config)
         {event=g1000.EC9X.change, action=msfs.input_event_executer("AS1000_PFD_1_FMS_Inner")},
         {event=g1000.EC9Y.change, action=msfs.input_event_executer("AS1000_PFD_1_FMS_Outer")},
         {event=g1000.EC9P.down, action=msfs.input_event_executer("AS1000_PFD_1_FMS_Inner_Button", 1)},
-
         {event=g1000.SW26.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_COM_Switch)")},
         {event=g1000.SW26.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_COM_Switch_Long)")},
         {event=g1000.SW27.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_DIRECTTO)")},
@@ -80,8 +73,10 @@ local function start(config)
         {event=g1000.SW31.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_CLR_Long)")},
         {event=g1000.SW32.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_ENT_Push)")},
     }
+end
 
-    local mfd_maps = {
+local function make_mfd_maps(g1000)
+    return {
         {event=g1000.EC1.change, action=msfs.input_event_executer("AS1000_MFD_1_NAV_Volume")},
         {event=g1000.EC2X.change, action=msfs.input_event_executer("AS1000_MFD_1_NAV_Khz")},
         {event=g1000.EC2Y.change, action=msfs.input_event_executer("AS1000_MFD_1_NAV_Mhz")},
@@ -103,7 +98,6 @@ local function start(config)
         {event=g1000.SW11.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_INC) (>H:AP_DN) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_DEC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_UP) }")},
         {event=g1000.SW12.down, action=msfs.mfwasm.rpn_executer("(>K:FLIGHT_LEVEL_CHANGE) (A:AIRSPEED INDICATED, knots) (>K:AP_SPD_VAR_SET)")},
         {event=g1000.SW13.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_DEC) (>H:AP_UP) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_INC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_DN) }")},
-
         {event=g1000.SW14.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_1)")},
         {event=g1000.SW15.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_2)")},
         {event=g1000.SW16.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_3)")},
@@ -116,7 +110,6 @@ local function start(config)
         {event=g1000.SW23.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_10)")},
         {event=g1000.SW24.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_11)")},
         {event=g1000.SW25.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_12)")},
-
         {event=g1000.EC5.change, action=msfs.input_event_executer("AS1000_MFD_1_COM_Volume")},
         {event=g1000.EC6X.change, action=msfs.input_event_executer("AS1000_MFD_1_COM_Khz")},
         {event=g1000.EC6Y.change, action=msfs.input_event_executer("AS1000_MFD_1_COM_Mhz")},
@@ -133,7 +126,6 @@ local function start(config)
         {event=g1000.EC9X.change, action=msfs.input_event_executer("AS1000_MFD_1_FMS_Inner")},
         {event=g1000.EC9Y.change, action=msfs.input_event_executer("AS1000_MFD_1_FMS_Outer")},
         {event=g1000.EC9P.down, action=msfs.input_event_executer("AS1000_MFD_1_FMS_Inner_Button", 1)},
-
         {event=g1000.SW26.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_COM_Switch)")},
         {event=g1000.SW26.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_COM_Switch_Long)")},
         {event=g1000.SW27.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_DIRECTTO)")},
@@ -144,55 +136,96 @@ local function start(config)
         {event=g1000.SW31.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_CLR_Long)")},
         {event=g1000.SW32.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_ENT_Push)")},
     }
+end
 
-    local displayno = config.simhid_g1000_display
-    local scale = config.simhid_g1000_display_scale
-    
-    local viewport = mapper.viewport({
-        name = "G1000 Viewport",
+local function make_viewport(name, displayno, scale)
+    return mapper.viewport({
+        name = name,
         displayno = displayno,
         x = 0, y = 0,
         width = scale, height = scale,
         bgcolor = "Black",
         aspect_ratio = 4.0 / 3.0,
     })
-    local pfd = viewport:register_view({
-        name = "PFD",
-        elements = {{object = mapper.captured_window({name = "G1000 PFD", window_title="AS1000_PFD"})}},
-        mappings = pfd_maps,
-    })
-    local mfd = viewport:register_view({
-        name = "MFD",
-        elements = {{object = mapper.captured_window({name = "G1000 MFD", window_title="AS1000_MFD"})}},
-        mappings = mfd_maps,
-    })
+end
 
-    local function toggle_view()
-        if viewport.current_view == pfd then
-            viewport:change_view(mfd)
-        else
-            viewport:change_view(pfd)
+local function start(config)
+    local scale = config.simhid_g1000_display_scale
+
+    g1000_context.device = common.open_simhid_g1000{config = config, modifiers = modifiers}
+    g1000_context.device2 = common.try_open_simhid_g1000_2{config = config, modifiers = modifiers}
+    local g1000 = g1000_context.device.events
+
+    if g1000_context.device2 then
+        -- Two-device mode: PFD fixed on device 1 / display 1, MFD fixed on device 2 / display 2.
+        local g1000_2 = g1000_context.device2.events
+        local display2 = common.get_simhid_g1000_2_display(config)
+
+        local vp_pfd = make_viewport("G1000 PFD", config.simhid_g1000_display, scale)
+        vp_pfd:register_view({
+            name = "PFD",
+            elements = {{object = mapper.captured_window({name = "G1000 PFD", window_title="AS1000_PFD"})}},
+            mappings = make_pfd_maps(g1000),
+        })
+
+        local vp_mfd = make_viewport("G1000 MFD", display2, scale)
+        vp_mfd:register_view({
+            name = "MFD",
+            elements = {{object = mapper.captured_window({name = "G1000 MFD", window_title="AS1000_MFD"})}},
+            mappings = make_mfd_maps(g1000_2),
+        })
+
+        return {
+            move_next_view = function() end,
+            move_previous_view = function() end,
+            global_mappings = {},
+            need_to_start_viewports = true,
+        }
+    else
+        -- Single-device mode: toggle between PFD and MFD on a single viewport.
+        local viewport = make_viewport("G1000 Viewport", config.simhid_g1000_display, scale)
+        local pfd = viewport:register_view({
+            name = "PFD",
+            elements = {{object = mapper.captured_window({name = "G1000 PFD", window_title="AS1000_PFD"})}},
+            mappings = make_pfd_maps(g1000),
+        })
+        local mfd = viewport:register_view({
+            name = "MFD",
+            elements = {{object = mapper.captured_window({name = "G1000 MFD", window_title="AS1000_MFD"})}},
+            mappings = make_mfd_maps(g1000),
+        })
+
+        local function toggle_view()
+            if viewport.current_view == pfd then
+                viewport:change_view(mfd)
+            else
+                viewport:change_view(pfd)
+            end
         end
+
+        viewport:set_mappings({
+            {event=g1000.AUX1D.down, action=toggle_view},
+            {event=g1000.AUX1U.down, action=toggle_view},
+            {event=g1000.AUX2D.down, action=toggle_view},
+            {event=g1000.AUX2U.down, action=toggle_view},
+        })
+
+        return {
+            move_next_view = toggle_view,
+            move_previous_view = toggle_view,
+            global_mappings = {},
+            need_to_start_viewports = true,
+        }
     end
-
-    viewport:set_mappings({
-        {event=g1000.AUX1D.down, action=toggle_view},
-        {event=g1000.AUX1U.down, action=toggle_view},
-        {event=g1000.AUX2D.down, action=toggle_view},
-        {event=g1000.AUX2U.down, action=toggle_view},
-    })
-
-    return {
-        move_next_view = toggle_view,
-        move_previous_view = toggle_view,
-        global_mappings = {},
-        need_to_start_viewports = true,
-    }
 end
 
 local function stop()
     g1000_context.device:close()
     g1000_context.device = nil
+    if g1000_context.device2 then
+        g1000_context.device2:close()
+        g1000_context.device2 = nil
+    end
 end
 
 return {

--- a/simhid_g1000/msfs/g1000abs.lua
+++ b/simhid_g1000/msfs/g1000abs.lua
@@ -1,24 +1,20 @@
-local g1000_context ={}
+local g1000_context = {}
 
 local common = require('lib/common')
 
-local function start(config)
-    g1000_context.device = common.open_simhid_g1000{
-        config = config,
-        modifiers = {
-            {class = "binary", modtype = "button"},
-            {class = "relative", modtype = "incdec"},
-            {name = "SW26", modtype = "button", modparam={longpress = 2000}},
-            {name = "SW31", modtype = "button", modparam={longpress = 2000}},
-            {name = "EC8U", modtype = "button", modparam={repeat_interval = 80}},
-            {name = "EC8D", modtype = "button", modparam={repeat_interval = 80}},
-            {name = "EC8R", modtype = "button", modparam={repeat_interval = 80}},
-            {name = "EC8L", modtype = "button", modparam={repeat_interval = 80}},
-        },
-    }
-    local g1000 = g1000_context.device.events
+local modifiers = {
+    {class = "binary", modtype = "button"},
+    {class = "relative", modtype = "incdec"},
+    {name = "SW26", modtype = "button", modparam={longpress = 2000}},
+    {name = "SW31", modtype = "button", modparam={longpress = 2000}},
+    {name = "EC8U", modtype = "button", modparam={repeat_interval = 80}},
+    {name = "EC8D", modtype = "button", modparam={repeat_interval = 80}},
+    {name = "EC8R", modtype = "button", modparam={repeat_interval = 80}},
+    {name = "EC8L", modtype = "button", modparam={repeat_interval = 80}},
+}
 
-    local pfd_maps = {
+local function make_pfd_maps(g1000)
+    return {
         {event=g1000.EC1.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_VOL_1_INC)")},
         {event=g1000.EC1.decrement, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_VOL_1_DEC)")},
         {event=g1000.EC2X.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_NAV_Small_INC)")},
@@ -46,7 +42,6 @@ local function start(config)
         {event=g1000.SW11.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_INC) (>H:AP_DN) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_DEC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_UP) }")},
         {event=g1000.SW12.down, action=msfs.mfwasm.rpn_executer("(>K:FLIGHT_LEVEL_CHANGE) (A:AIRSPEED INDICATED, knots) (>K:AP_SPD_VAR_SET)")},
         {event=g1000.SW13.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_DEC) (>H:AP_UP) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_INC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_DN) }")},
-
         {event=g1000.SW14.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_1)")},
         {event=g1000.SW15.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_2)")},
         {event=g1000.SW16.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_3)")},
@@ -59,7 +54,6 @@ local function start(config)
         {event=g1000.SW23.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_10)")},
         {event=g1000.SW24.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_11)")},
         {event=g1000.SW25.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_SOFTKEYS_12)")},
-
         {event=g1000.EC5.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_VOL_2_INC)")},
         {event=g1000.EC5.decrement, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_VOL_2_DEC)")},
         {event=g1000.EC6X.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_COM_Small_INC)")},
@@ -84,7 +78,6 @@ local function start(config)
         {event=g1000.EC9Y.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_FMS_Lower_INC)")},
         {event=g1000.EC9Y.decrement, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_FMS_Lower_DEC)")},
         {event=g1000.EC9P.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_FMS_Upper_PUSH)")},
-
         {event=g1000.SW26.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_COM_Switch)")},
         {event=g1000.SW26.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_COM_Switch_Long)")},
         {event=g1000.SW27.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_DIRECTTO)")},
@@ -95,8 +88,10 @@ local function start(config)
         {event=g1000.SW31.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_CLR_Long)")},
         {event=g1000.SW32.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_PFD_ENT_Push)")},
     }
+end
 
-    local mfd_maps = {
+local function make_mfd_maps(g1000)
+    return {
         {event=g1000.EC1.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_VOL_1_INC)")},
         {event=g1000.EC1.decrement, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_VOL_1_DEC)")},
         {event=g1000.EC2X.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_NAV_Small_INC)")},
@@ -124,7 +119,6 @@ local function start(config)
         {event=g1000.SW11.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_INC) (>H:AP_DN) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_DEC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_UP) }")},
         {event=g1000.SW12.down, action=msfs.mfwasm.rpn_executer("(>K:FLIGHT_LEVEL_CHANGE) (A:AIRSPEED INDICATED, knots) (>K:AP_SPD_VAR_SET)")},
         {event=g1000.SW13.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT VERTICAL HOLD, Bool) if{ (>K:AP_VS_VAR_DEC) (>H:AP_UP) } (A:AUTOPILOT FLIGHT LEVEL CHANGE, Bool) if{ (>K:AP_SPD_VAR_INC) } (A:AUTOPILOT PITCH HOLD, Bool) if{ (>K:AP_PITCH_REF_INC_DN) }")},
-
         {event=g1000.SW14.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_1)")},
         {event=g1000.SW15.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_2)")},
         {event=g1000.SW16.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_3)")},
@@ -137,7 +131,6 @@ local function start(config)
         {event=g1000.SW23.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_10)")},
         {event=g1000.SW24.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_11)")},
         {event=g1000.SW25.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_SOFTKEYS_12)")},
-
         {event=g1000.EC5.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_VOL_2_INC)")},
         {event=g1000.EC5.decrement, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_VOL_2_DEC)")},
         {event=g1000.EC6X.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_COM_Small_INC)")},
@@ -162,7 +155,6 @@ local function start(config)
         {event=g1000.EC9Y.increment, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_FMS_Lower_INC)")},
         {event=g1000.EC9Y.decrement, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_FMS_Lower_DEC)")},
         {event=g1000.EC9P.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_FMS_Upper_PUSH)")},
-
         {event=g1000.SW26.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_COM_Switch)")},
         {event=g1000.SW26.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_COM_Switch_Long)")},
         {event=g1000.SW27.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_DIRECTTO)")},
@@ -173,55 +165,96 @@ local function start(config)
         {event=g1000.SW31.longpressed, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_CLR_Long)")},
         {event=g1000.SW32.down, action=msfs.mfwasm.rpn_executer("(>H:AS1000_MFD_ENT_Push)")},
     }
+end
 
-    local displayno = config.simhid_g1000_display
-    local scale = config.simhid_g1000_display_scale
-    
-    local viewport = mapper.viewport({
-        name = "G1000 Viewport",
+local function make_viewport(name, displayno, scale)
+    return mapper.viewport({
+        name = name,
         displayno = displayno,
         x = 0, y = 0,
         width = scale, height = scale,
         bgcolor = "Black",
         aspect_ratio = 4.0 / 3.0,
     })
-    local pfd = viewport:register_view({
-        name = "PFD",
-        elements = {{object = mapper.captured_window({name = "G1000 PFD", window_title="AS1000_PFD"})}},
-        mappings = pfd_maps,
-    })
-    local mfd = viewport:register_view({
-        name = "MFD",
-        elements = {{object = mapper.captured_window({name = "G1000 MFD", window_title="AS1000_MFD"})}},
-        mappings = mfd_maps,
-    })
+end
 
-    local function toggle_view()
-        if viewport.current_view == pfd then
-            viewport:change_view(mfd)
-        else
-            viewport:change_view(pfd)
+local function start(config)
+    local scale = config.simhid_g1000_display_scale
+
+    g1000_context.device = common.open_simhid_g1000{config = config, modifiers = modifiers}
+    g1000_context.device2 = common.try_open_simhid_g1000_2{config = config, modifiers = modifiers}
+    local g1000 = g1000_context.device.events
+
+    if g1000_context.device2 then
+        -- Two-device mode: PFD fixed on device 1 / display 1, MFD fixed on device 2 / display 2.
+        local g1000_2 = g1000_context.device2.events
+        local display2 = common.get_simhid_g1000_2_display(config)
+
+        local vp_pfd = make_viewport("G1000 PFD", config.simhid_g1000_display, scale)
+        vp_pfd:register_view({
+            name = "PFD",
+            elements = {{object = mapper.captured_window({name = "G1000 PFD", window_title="AS1000_PFD"})}},
+            mappings = make_pfd_maps(g1000),
+        })
+
+        local vp_mfd = make_viewport("G1000 MFD", display2, scale)
+        vp_mfd:register_view({
+            name = "MFD",
+            elements = {{object = mapper.captured_window({name = "G1000 MFD", window_title="AS1000_MFD"})}},
+            mappings = make_mfd_maps(g1000_2),
+        })
+
+        return {
+            move_next_view = function() end,
+            move_previous_view = function() end,
+            global_mappings = {},
+            need_to_start_viewports = true,
+        }
+    else
+        -- Single-device mode: toggle between PFD and MFD on a single viewport.
+        local viewport = make_viewport("G1000 Viewport", config.simhid_g1000_display, scale)
+        local pfd = viewport:register_view({
+            name = "PFD",
+            elements = {{object = mapper.captured_window({name = "G1000 PFD", window_title="AS1000_PFD"})}},
+            mappings = make_pfd_maps(g1000),
+        })
+        local mfd = viewport:register_view({
+            name = "MFD",
+            elements = {{object = mapper.captured_window({name = "G1000 MFD", window_title="AS1000_MFD"})}},
+            mappings = make_mfd_maps(g1000),
+        })
+
+        local function toggle_view()
+            if viewport.current_view == pfd then
+                viewport:change_view(mfd)
+            else
+                viewport:change_view(pfd)
+            end
         end
+
+        viewport:set_mappings({
+            {event=g1000.AUX1D.down, action=toggle_view},
+            {event=g1000.AUX1U.down, action=toggle_view},
+            {event=g1000.AUX2D.down, action=toggle_view},
+            {event=g1000.AUX2U.down, action=toggle_view},
+        })
+
+        return {
+            move_next_view = toggle_view,
+            move_previous_view = toggle_view,
+            global_mappings = {},
+            need_to_start_viewports = true,
+        }
     end
-
-    viewport:set_mappings({
-        {event=g1000.AUX1D.down, action=toggle_view},
-        {event=g1000.AUX1U.down, action=toggle_view},
-        {event=g1000.AUX2D.down, action=toggle_view},
-        {event=g1000.AUX2U.down, action=toggle_view},
-    })
-
-    return {
-        move_next_view = toggle_view,
-        move_previous_view = toggle_view,
-        global_mappings = {},
-        need_to_start_viewports = true,
-    }
 end
 
 local function stop()
     g1000_context.device:close()
     g1000_context.device = nil
+    if g1000_context.device2 then
+        g1000_context.device2:close()
+        g1000_context.device2 = nil
+    end
 end
 
 return {

--- a/simhid_g1000/msfs/g3x_touch.lua
+++ b/simhid_g1000/msfs/g3x_touch.lua
@@ -77,106 +77,19 @@ aircraft_defs["VL3"] = {views={"G3X Touch PFD","G3X Touch MFD"}, aptype=3}
 aircraft_defs["Volocity Microsoft"] = {views={"G3X Touch PFD"}, aptype=3}
 aircraft_fallback = {views={"G3X Touch PFD"}, aptype=3}
 
+local modifiers = {
+    {class = "binary", modtype = "button"},
+    {class = "relative", modtype = "incdec"},
+}
+
 --------------------------------------------------------------------------------------
--- Initialize function
+-- Build viewport-level AP control mappings for a given device and AP panel type.
+-- Called once per viewport so each device's physical knobs/buttons are wired up.
 --------------------------------------------------------------------------------------
-function context.start(config, aircraft)
-    local display = config.simhid_g1000_display
-    local scale = config.simhid_g1000_display_scale
-    
-    local viewport = mapper.viewport{
-        name = "G3X Touch",
-        displayno = display,
-        x = 0, y = 0, width = scale, height = scale,
-        aspect_ratio = 4 / 3,
-    }
-
-    context.device = common.open_simhid_g1000{
-        config = config,
-        modifiers = {
-            {class = "binary", modtype = "button"},
-            {class = "relative", modtype = "incdec"},
-        },
-    }
-    local g1000 = context.device.events
-
-    local aircraft_def = aircraft_defs[aircraft]
-    if not aircraft_def then
-        for name, def in pairs(aircraft_defs) do
-            if string.find(aircraft, name) ~= nil then
-                aircraft_def = def
-                break
-            end
-        end
-        if not aircraft_def then
-            aircraft_def = aircraft_fallback
-        end
-    end
-
-    context.g3x_touch_view.init(context.device, aircraft_def.aptype ~= 2)
-    context.views = {}
-    context.canvases = {}
-    local global_mappings = {}
-    local observed_data = {}
-    local ap_panel_def = ap_panel_defs[aircraft_def.aptype]
-    if ap_panel_def.background then
-        context.background = graphics.bitmap(ap_panel_def.background)
-    end
-
-    for name, indicator in pairs(ap_panel_def.indicators) do
-        context.canvases[name] = {}
-        observed_data[#observed_data + 1] = {rpn=indicator.rpn, event=indicator.evid}
-        global_mappings[#global_mappings + 1] = {event=indicator.evid, action=function(evid, value)
-            for i, canvas in ipairs(context.canvases[name]) do
-                canvas:set_value(value)
-            end
-        end}
-    end
-    msfs.mfwasm.add_observed_data(observed_data)
-
-    for i, name in ipairs(aircraft_def.views) do
-        local view_def = context.g3x_touch_view.create_view(name, i)
-        if context.background then
-            view_def.background = context.background
-        end
-        for name, button in pairs(ap_panel_def.buttons) do
-            view_def.elements[#view_def.elements + 1] = {
-                object = mapper.view_elements.operable_area{round_ratio = button.attr.rratio, event_tap = button.evid},
-                x = button.x, y = button.y,
-                width = button.attr.width, height = button.attr.height
-            }
-            view_def.mappings[#view_def.mappings + 1] = {event = button.evid, action = button.action}
-            if button.image then
-                local rctx = graphics.rendering_context(view_def.background)
-                rctx:draw_bitmap(button.image, button.x, button.y)
-                rctx:finish_rendering()
-            end
-        end
-        for name, indicator in pairs(ap_panel_def.indicators) do
-            local canvas = mapper.view_elements.canvas{
-                logical_width = indicator.attr.width,
-                logical_height = indicator.attr.height,
-                value = 0,
-                renderer = function (ctx, value)
-                    local image = indicator.bitmaps[value + 1]
-                    if image then
-                        ctx:draw_bitmap(image, 0, 0)
-                    end
-                end
-            }
-            view_def.elements[#view_def.elements + 1] = {
-                object = canvas,
-                x = indicator.x, y = indicator.y,
-                width = indicator.attr.width, height = indicator.attr.height
-            }
-            context.canvases[name][#context.canvases[name] + 1] = canvas
-        end
-        context.views[i] = viewport:register_view(view_def)
-    end
-
-    if aircraft_def.aptype == 1 then
-        -- Airecraft which install GMC 307 control panel
-        viewport:set_mappings{
+local function make_ap_viewport_mappings(g1000, aptype)
+    if aptype == 1 then
+        -- Aircraft with GMC 307 control panel
+        return {
             {event=g1000.SW2.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT DISENGAGED, Bool) ! if{ (>K:AP_MASTER) (A:AUTOPILOT MASTER, Bool) ! if{ (>H:Generic_Autopilot_Manual_Off) } els{ (A:AUTOPILOT FLIGHT DIRECTOR ACTIVE, Bool) ! if{ 1 (>K:TOGGLE_FLIGHT_DIRECTOR) } } }")},
             {event=g1000.SW3.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT MASTER, Bool) ! if{ 1 (>K:TOGGLE_FLIGHT_DIRECTOR) }")},
             {event=g1000.SW4.down, action=msfs.mfwasm.rpn_executer("(>K:AP_PANEL_HEADING_HOLD)")},
@@ -197,8 +110,9 @@ function context.start(config, aircraft)
             {event=g1000.EC7Y.increment, action=msfs.mfwasm.rpn_executer("1 (>K:KOHLSMAN_INC) (>H:AP_BARO_Up)")},
             {event=g1000.EC7Y.decrement, action=msfs.mfwasm.rpn_executer("1 (>K:KOHLSMAN_DEC) (>H:AP_BARO_Down)")},
         }
-    elseif aircraft_def.aptype == 2 then
-        viewport:set_mappings{
+    elseif aptype == 2 then
+        -- King Air 350
+        return {
             {event=g1000.SW2.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT DISENGAGED, Bool) ! if{ (>K:AP_MASTER) (A:AUTOPILOT MASTER, Bool) ! if{ (>H:Generic_Autopilot_Manual_Off) } els{ (A:AUTOPILOT FLIGHT DIRECTOR ACTIVE, Bool) ! if{ 1 (>K:TOGGLE_FLIGHT_DIRECTOR) } } }")},
             {event=g1000.SW3.down, action=msfs.mfwasm.rpn_executer("(A:AUTOPILOT MASTER, Bool) ! if{ 1 (>K:TOGGLE_FLIGHT_DIRECTOR) }")},
             {event=g1000.SW4.down, action=msfs.mfwasm.rpn_executer("(>K:AP_PANEL_HEADING_HOLD)")},
@@ -229,8 +143,8 @@ function context.start(config, aircraft)
             {event=g1000.EC7Y.decrement, action=msfs.mfwasm.rpn_executer("1 (>K:KOHLSMAN_DEC) (>H:AP_BARO_Down)")},
         }
     else
-        -- No auto pilot system is enabled
-        viewport:set_mappings{
+        -- No autopilot system
+        return {
             {event=g1000.EC3.increment, action=msfs.mfwasm.rpn_executer("1 (>K:HEADING_BUG_INC)")},
             {event=g1000.EC3.decrement, action=msfs.mfwasm.rpn_executer("1 (>K:HEADING_BUG_DEC)")},
             {event=g1000.EC2X.increment, action=msfs.mfwasm.rpn_executer("100 (>K:AP_ALT_VAR_INC)")},
@@ -241,31 +155,204 @@ function context.start(config, aircraft)
             {event=g1000.EC7Y.decrement, action=msfs.mfwasm.rpn_executer("1 (>K:KOHLSMAN_DEC) (>H:AP_BARO_Down)")},
         }
     end
+end
 
-    context.current_view = 1
-    local function change_view(d)
-        context.current_view = context.current_view + d
-        if context.current_view > #context.views then
-            context.current_view = 1
-        elseif context.current_view < 1 then
-            context.current_view = #context.views
+--------------------------------------------------------------------------------------
+-- Add AP panel button operable areas and indicator canvases to a view definition.
+-- Indicator canvases are appended to context.canvases so all instances are updated
+-- together when the observed RPN value changes.
+--------------------------------------------------------------------------------------
+local function add_ap_elements_to_view(view_def, ap_panel_def)
+    for name, button in pairs(ap_panel_def.buttons) do
+        view_def.elements[#view_def.elements + 1] = {
+            object = mapper.view_elements.operable_area{round_ratio = button.attr.rratio, event_tap = button.evid},
+            x = button.x, y = button.y,
+            width = button.attr.width, height = button.attr.height
+        }
+        view_def.mappings[#view_def.mappings + 1] = {event = button.evid, action = button.action}
+        if button.image then
+            local rctx = graphics.rendering_context(view_def.background)
+            rctx:draw_bitmap(button.image, button.x, button.y)
+            rctx:finish_rendering()
         end
-        viewport:change_view(context.views[context.current_view])
+    end
+    for name, indicator in pairs(ap_panel_def.indicators) do
+        local canvas = mapper.view_elements.canvas{
+            logical_width = indicator.attr.width,
+            logical_height = indicator.attr.height,
+            value = 0,
+            renderer = function (ctx, value)
+                local image = indicator.bitmaps[value + 1]
+                if image then
+                    ctx:draw_bitmap(image, 0, 0)
+                end
+            end
+        }
+        view_def.elements[#view_def.elements + 1] = {
+            object = canvas,
+            x = indicator.x, y = indicator.y,
+            width = indicator.attr.width, height = indicator.attr.height
+        }
+        context.canvases[name][#context.canvases[name] + 1] = canvas
+    end
+end
+
+--------------------------------------------------------------------------------------
+-- Initialize function
+--------------------------------------------------------------------------------------
+function context.start(config, aircraft)
+    local display = config.simhid_g1000_display
+    local scale = config.simhid_g1000_display_scale
+
+    context.device = common.open_simhid_g1000{config = config, modifiers = modifiers}
+    context.device2 = common.try_open_simhid_g1000_2{config = config, modifiers = modifiers}
+    local g1000 = context.device.events
+
+    local aircraft_def = aircraft_defs[aircraft]
+    if not aircraft_def then
+        for name, def in pairs(aircraft_defs) do
+            if string.find(aircraft, name) ~= nil then
+                aircraft_def = def
+                break
+            end
+        end
+        if not aircraft_def then
+            aircraft_def = aircraft_fallback
+        end
     end
 
-    viewport:add_mappings{
-        {event=g1000.AUX1D.down, action=function () change_view(1) end},
-        {event=g1000.AUX1U.down, action=function () change_view(-1) end},
-        {event=g1000.AUX2D.down, action=function () change_view(1) end},
-        {event=g1000.AUX2U.down, action=function () change_view(-1) end},
-    }
+    local has_buttons = aircraft_def.aptype ~= 2
+    local ap_panel_def = ap_panel_defs[aircraft_def.aptype]
 
-    return {
-        move_next_view = function () change_view(1) end,
-        move_previous_view = function () change_view(-1) end,
-        global_mappings = {global_mappings},
-        need_to_start_viewports = true,
-    }
+    context.views = {}
+    context.canvases = {}
+    local global_mappings = {}
+    local observed_data = {}
+
+    if ap_panel_def.background then
+        context.background = graphics.bitmap(ap_panel_def.background)
+    end
+
+    for name, indicator in pairs(ap_panel_def.indicators) do
+        context.canvases[name] = {}
+        observed_data[#observed_data + 1] = {rpn=indicator.rpn, event=indicator.evid}
+        global_mappings[#global_mappings + 1] = {event=indicator.evid, action=function(evid, value)
+            for i, canvas in ipairs(context.canvases[name]) do
+                canvas:set_value(value)
+            end
+        end}
+    end
+    msfs.mfwasm.add_observed_data(observed_data)
+
+    if context.device2 and #aircraft_def.views >= 2 then
+        --------------------------------------------------------------------------------------
+        -- Two-device mode: view 1 on display 1 / device 1, remaining views on display 2 / device 2.
+        -- Each viewport shows its assigned view(s) without needing to cycle.
+        --------------------------------------------------------------------------------------
+        local g1000_2 = context.device2.events
+        local display2 = common.get_simhid_g1000_2_display(config)
+
+        -- Viewport 1: device 1, view 1
+        local viewport1 = mapper.viewport{
+            name = "G3X Touch PFD",
+            displayno = display,
+            x = 0, y = 0, width = scale, height = scale,
+            aspect_ratio = 4 / 3,
+        }
+        context.g3x_touch_view.init(context.device, has_buttons)
+        local view1_def = context.g3x_touch_view.create_view(aircraft_def.views[1], 1)
+        if context.background then view1_def.background = context.background end
+        add_ap_elements_to_view(view1_def, ap_panel_def)
+        context.views[1] = viewport1:register_view(view1_def)
+        viewport1:set_mappings(make_ap_viewport_mappings(g1000, aircraft_def.aptype))
+
+        -- Viewport 2: device 2, views 2 through N
+        local viewport2 = mapper.viewport{
+            name = "G3X Touch MFD",
+            displayno = display2,
+            x = 0, y = 0, width = scale, height = scale,
+            aspect_ratio = 4 / 3,
+        }
+        -- Re-initialise with device 2 so create_view uses its events for view-level knob mappings.
+        context.g3x_touch_view.init(context.device2, has_buttons)
+        for i = 2, #aircraft_def.views do
+            local view_def = context.g3x_touch_view.create_view(aircraft_def.views[i], i)
+            if context.background then view_def.background = context.background end
+            add_ap_elements_to_view(view_def, ap_panel_def)
+            context.views[i] = viewport2:register_view(view_def)
+        end
+        viewport2:set_mappings(make_ap_viewport_mappings(g1000_2, aircraft_def.aptype))
+
+        -- If viewport 2 holds more than one view, let device 2's AUX buttons cycle them.
+        if #aircraft_def.views > 2 then
+            local vp2_view_count = #aircraft_def.views - 1
+            local vp2_current = 1
+            local function change_vp2_view(d)
+                vp2_current = vp2_current + d
+                if vp2_current > vp2_view_count then vp2_current = 1
+                elseif vp2_current < 1 then vp2_current = vp2_view_count
+                end
+                viewport2:change_view(context.views[vp2_current + 1])
+            end
+            viewport2:add_mappings{
+                {event=g1000_2.AUX1D.down, action=function() change_vp2_view(1) end},
+                {event=g1000_2.AUX1U.down, action=function() change_vp2_view(-1) end},
+                {event=g1000_2.AUX2D.down, action=function() change_vp2_view(1) end},
+                {event=g1000_2.AUX2U.down, action=function() change_vp2_view(-1) end},
+            }
+        end
+
+        return {
+            move_next_view = function() end,
+            move_previous_view = function() end,
+            global_mappings = {global_mappings},
+            need_to_start_viewports = true,
+        }
+    else
+        --------------------------------------------------------------------------------------
+        -- Single-device mode: all views in one viewport, AUX buttons cycle through them.
+        --------------------------------------------------------------------------------------
+        local viewport = mapper.viewport{
+            name = "G3X Touch",
+            displayno = display,
+            x = 0, y = 0, width = scale, height = scale,
+            aspect_ratio = 4 / 3,
+        }
+
+        context.g3x_touch_view.init(context.device, has_buttons)
+        for i, name in ipairs(aircraft_def.views) do
+            local view_def = context.g3x_touch_view.create_view(name, i)
+            if context.background then view_def.background = context.background end
+            add_ap_elements_to_view(view_def, ap_panel_def)
+            context.views[i] = viewport:register_view(view_def)
+        end
+        viewport:set_mappings(make_ap_viewport_mappings(g1000, aircraft_def.aptype))
+
+        context.current_view = 1
+        local function change_view(d)
+            context.current_view = context.current_view + d
+            if context.current_view > #context.views then
+                context.current_view = 1
+            elseif context.current_view < 1 then
+                context.current_view = #context.views
+            end
+            viewport:change_view(context.views[context.current_view])
+        end
+
+        viewport:add_mappings{
+            {event=g1000.AUX1D.down, action=function () change_view(1) end},
+            {event=g1000.AUX1U.down, action=function () change_view(-1) end},
+            {event=g1000.AUX2D.down, action=function () change_view(1) end},
+            {event=g1000.AUX2U.down, action=function () change_view(-1) end},
+        }
+
+        return {
+            move_next_view = function () change_view(1) end,
+            move_previous_view = function () change_view(-1) end,
+            global_mappings = {global_mappings},
+            need_to_start_viewports = true,
+        }
+    end
 end
 
 
@@ -278,6 +365,10 @@ function context.stop()
     context.g3x_touch_view.term()
     context.device:close()
     context.device = nil
+    if context.device2 then
+        context.device2:close()
+        context.device2 = nil
+    end
     context.background = nil
     msfs.mfwasm.clear_observed_data()
 end

--- a/simhid_g1000/msfs/lib/common.lua
+++ b/simhid_g1000/msfs/lib/common.lua
@@ -516,6 +516,37 @@ function module.open_simhid_g1000(args)
     end
 end
 
+-- Try to open a second SimHID G1000. Returns nil if not configured or if the device is
+-- not found (allowing graceful fallback to single-device mode).
+function module.try_open_simhid_g1000_2(args)
+    if args.config.simhid_g1000_2_identifier == nil then
+        return nil
+    end
+    if args.config.simhid_g1000_mock then
+        return module.simhid_g1000_mock(args.config)
+    end
+    local ok, device = pcall(function()
+        return mapper.device{
+            name = "SimHID G1000 #2",
+            type = "simhid",
+            identifier = args.config.simhid_g1000_2_identifier,
+            modifiers = args.modifiers,
+        }
+    end)
+    if ok then
+        mapper.print("Second SimHID G1000 connected")
+        return device
+    else
+        mapper.print("Second SimHID G1000 not available: " .. tostring(device))
+        return nil
+    end
+end
+
+-- Returns the display number for the second SimHID, falling back to the primary display.
+function module.get_simhid_g1000_2_display(config)
+    return config.simhid_g1000_2_display or config.simhid_g1000_display
+end
+
 local simhid_g1000_units = {
     'AUX1U', 'AUX1D', 'AUX1P',
     'AUX2U', 'AUX2D', 'AUX2P',


### PR DESCRIPTION
## Summary

- Adds optional support for a second SimHID G1000 device, enabling dedicated PFD and MFD displays without view toggling
- Falls back transparently to existing single-device behaviour when only one device is connected
- All new config keys default to `nil` so existing setups require no changes

## Changes

**`config.lua`** — two new overridable keys:
```lua
simhid_g1000_2_identifier = nil,   -- e.g. {path = "COM4"}
simhid_g1000_2_display = nil,       -- e.g. 3 (defaults to simhid_g1000_display)
```

**`lib/common.lua`** — two new helpers:
- `try_open_simhid_g1000_2(args)` — opens the second device via `pcall`, returns `nil` if not configured or not found
- `get_simhid_g1000_2_display(config)` — returns the second display number, falling back to the primary

**`g1000.lua` / `g1000abs.lua`** — refactored with extracted helpers (`make_pfd_maps`, `make_mfd_maps`, `make_viewport`); in dual-device mode creates two fixed viewports instead of one toggling viewport

**`g3x_touch.lua`** — refactored with extracted helpers (`make_ap_viewport_mappings`, `add_ap_elements_to_view`); in dual-device mode splits views across two viewports when the aircraft has ≥2 views (King Air 350, VL3)

## Test plan

- [ ] Single SimHID connected: behaviour identical to before (toggle with AUX buttons)
- [ ] Two SimHIDs connected (King Air 350): PFD fixed on display 1, MFD fixed on display 2, no toggling needed
- [ ] Two SimHIDs connected (G1000 aircraft): PFD fixed on display 1, MFD fixed on display 2
- [ ] `simhid_g1000_2_identifier` set but device not physically present: graceful fallback to single-device mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)